### PR TITLE
Expand RemarkCommand test coverage

### DIFF
--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -29,8 +29,9 @@ import seedu.address.testutil.EditPersonDescriptorBuilder;
  */
 public class CommandTestUtil {
 
-    public static final String LONG_REMARK = "This is a very long remark used for testing the capability of handling " +
-            "large remarks " + "in the system which might be used to store comprehensive information about a person.";
+    public static final String LONG_REMARK = "This is a very long remark used for testing the capability of handling "
+            + "large remarks "
+            + "in the system which might be used to store comprehensive information about a person.";
     public static final String REMARK_STUB = "Some remark";
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -29,6 +29,9 @@ import seedu.address.testutil.EditPersonDescriptorBuilder;
  */
 public class CommandTestUtil {
 
+    public static final String LONG_REMARK = "This is a very long remark used for testing the capability of handling " +
+            "large remarks " + "in the system which might be used to store comprehensive information about a person.";
+    public static final String REMARK_STUB = "Some remark";
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
     public static final String VALID_PHONE_AMY = "11111111";

--- a/src/test/java/seedu/address/logic/commands/RemarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RemarkCommandTest.java
@@ -1,10 +1,13 @@
 package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.LONG_REMARK;
+import static seedu.address.logic.commands.CommandTestUtil.REMARK_STUB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_REMARK_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
@@ -22,8 +25,6 @@ import seedu.address.model.person.Remark;
 import seedu.address.testutil.PersonBuilder;
 
 class RemarkCommandTest {
-
-    private static final String REMARK_STUB = "Some remark";
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
@@ -110,5 +111,137 @@ class RemarkCommandTest {
         RemarkCommand remarkCommand = new RemarkCommand(outOfBoundIndex, new Remark(VALID_REMARK_BOB));
 
         assertCommandFailure(remarkCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    /**
+     * Test Adding a Long Remark to a Person in the Unfiltered List
+     */
+    @Test
+    public void execute_addLongRemarkUnfilteredList_success() {
+        // Setup first person for testing
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+
+        Person editedPerson = new PersonBuilder(firstPerson).withRemark(LONG_REMARK).build();
+
+        RemarkCommand remarkCommand = new RemarkCommand(INDEX_FIRST_PERSON, new Remark(LONG_REMARK));
+
+        String expectedMessage = String.format(RemarkCommand.MESSAGE_ADD_REMARK_SUCCESS, editedPerson);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(firstPerson, editedPerson);
+
+        assertCommandSuccess(remarkCommand, model,
+                new CommandResult(expectedMessage).withPersonToShow(model.findIndex(editedPerson)), expectedModel);
+    }
+
+    /**
+     * Test Adding an Empty Remark
+     */
+    @Test
+    public void execute_addEmptyRemarkUnfilteredList_success() {
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        String emptyRemark = "";
+        Person editedPerson = new PersonBuilder(firstPerson).withRemark(emptyRemark).build();
+
+        RemarkCommand remarkCommand = new RemarkCommand(INDEX_FIRST_PERSON, new Remark(emptyRemark));
+
+        String expectedMessage = String.format(RemarkCommand.MESSAGE_DELETE_REMARK_SUCCESS, editedPerson);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(firstPerson, editedPerson);
+
+        assertCommandSuccess(remarkCommand, model,
+                new CommandResult(expectedMessage).withPersonToShow(model.findIndex(editedPerson)), expectedModel);
+    }
+
+    /**
+     * Test No Change in Remark
+     */
+    @Test
+    public void execute_noChangeInRemarkUnfilteredList_success() {
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        String existingRemark = firstPerson.getRemark().value;
+        Person editedPerson = new PersonBuilder(firstPerson).withRemark(existingRemark).build();  // No change in remark
+
+        RemarkCommand remarkCommand = new RemarkCommand(INDEX_FIRST_PERSON, new Remark(existingRemark));
+
+        String expectedMessage = String.format(RemarkCommand.MESSAGE_ADD_REMARK_SUCCESS, editedPerson);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(firstPerson, editedPerson);
+
+        assertCommandSuccess(remarkCommand, model,
+                new CommandResult(expectedMessage).withPersonToShow(model.findIndex(editedPerson)), expectedModel);
+    }
+
+    /**
+     * Test Adding a Remark to a Newly Added Person
+     */
+    @Test
+    public void execute_addRemarkToNewPerson_success() {
+        Person newPerson = new PersonBuilder().build();  // Build a default person
+        model.addPerson(newPerson);  // Assume there's a method in the model to add a person
+        Index newPersonIndex = Index.fromOneBased(model.getFilteredPersonList().size()); // Last person, newly added
+
+        Person editedPerson = new PersonBuilder(newPerson).withRemark(VALID_REMARK_BOB).build();
+
+        RemarkCommand remarkCommand = new RemarkCommand(newPersonIndex, new Remark(VALID_REMARK_BOB));
+
+        String expectedMessage = String.format(RemarkCommand.MESSAGE_ADD_REMARK_SUCCESS, editedPerson);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(newPerson, editedPerson);
+
+        assertCommandSuccess(remarkCommand, model,
+                new CommandResult(expectedMessage).withPersonToShow(model.findIndex(editedPerson)), expectedModel);
+    }
+
+    /**
+     * Ensure remark command works on filtered list
+     */
+    @Test
+    public void execute_addRemarkFilteredList_success() {
+        // Filter the list to only show the second person
+        showPersonAtIndex(model, INDEX_SECOND_PERSON);
+
+        // Get the person from the filtered and unfiltered list to verify the correct person is in view
+        Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person personInFullList = model.getAddressBook().getPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
+        assertTrue(personInFilteredList.equals(personInFullList));
+
+        Person editedPerson = new PersonBuilder(personInFilteredList).withRemark(VALID_REMARK_BOB).build();
+
+        RemarkCommand remarkCommand = new RemarkCommand(INDEX_FIRST_PERSON, new Remark(VALID_REMARK_BOB));
+
+        String expectedMessage = String.format(RemarkCommand.MESSAGE_ADD_REMARK_SUCCESS, editedPerson);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(personInFullList, editedPerson);
+        expectedModel.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+
+        assertCommandSuccess(
+                remarkCommand,
+                model,
+                new CommandResult(expectedMessage).withPersonToShow(INDEX_SECOND_PERSON.getZeroBased()),
+                expectedModel);
+    }
+
+    /**
+     * Test Changing Remark on a Person Already with a Remark
+     */
+    @Test
+    public void execute_changeRemarkUnfilteredList_success() {
+
+        Person personToEdit = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
+        Person editedPerson = new PersonBuilder(personToEdit).withRemark(VALID_REMARK_BOB).build();
+
+        RemarkCommand remarkCommand = new RemarkCommand(INDEX_SECOND_PERSON, new Remark(VALID_REMARK_BOB));
+
+        String expectedMessage = String.format(RemarkCommand.MESSAGE_ADD_REMARK_SUCCESS, editedPerson);
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.setPerson(personToEdit, editedPerson);
+
+        assertCommandSuccess(remarkCommand, model, new CommandResult(expectedMessage).withPersonToShow(model.findIndex(editedPerson)), expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/RemarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RemarkCommandTest.java
@@ -161,7 +161,7 @@ class RemarkCommandTest {
     public void execute_noChangeInRemarkUnfilteredList_success() {
         Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         String existingRemark = firstPerson.getRemark().value;
-        Person editedPerson = new PersonBuilder(firstPerson).withRemark(existingRemark).build();  // No change in remark
+        Person editedPerson = new PersonBuilder(firstPerson).withRemark(existingRemark).build();
 
         RemarkCommand remarkCommand = new RemarkCommand(INDEX_FIRST_PERSON, new Remark(existingRemark));
 
@@ -179,8 +179,8 @@ class RemarkCommandTest {
      */
     @Test
     public void execute_addRemarkToNewPerson_success() {
-        Person newPerson = new PersonBuilder().build();  // Build a default person
-        model.addPerson(newPerson);  // Assume there's a method in the model to add a person
+        Person newPerson = new PersonBuilder().build();
+        model.addPerson(newPerson);
         Index newPersonIndex = Index.fromOneBased(model.getFilteredPersonList().size()); // Last person, newly added
 
         Person editedPerson = new PersonBuilder(newPerson).withRemark(VALID_REMARK_BOB).build();
@@ -242,6 +242,7 @@ class RemarkCommandTest {
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.setPerson(personToEdit, editedPerson);
 
-        assertCommandSuccess(remarkCommand, model, new CommandResult(expectedMessage).withPersonToShow(model.findIndex(editedPerson)), expectedModel);
+        assertCommandSuccess(remarkCommand, model,
+                new CommandResult(expectedMessage).withPersonToShow(model.findIndex(editedPerson)), expectedModel);
     }
 }


### PR DESCRIPTION
# Expand RemarkCommand Test Coverage

## Overview
This pull request introduces comprehensive enhancements to the testing suite for the `RemarkCommand` in our application. It aims to significantly increase test coverage by including new scenarios and ensures that the command behaves consistently across both unfiltered and filtered list contexts.

## Changes Made
- **New Tests for Long and Empty Remarks**: These tests validate the command's ability to handle edge cases such as extremely long remarks and empty strings.
- **Tests for Unmodified Remarks**: Added to confirm that the command does not alter the person's data when the remark provided is identical to the existing one.
- **Integration Test with Newly Added Person**: Checks the command's functionality when applied to newly added persons, ensuring that our model updates correctly in dynamic conditions.
- **Functionality in Filtered Lists**: Ensures that the command functions as expected even when the list view is filtered, a crucial aspect for user experience.
- **Editing Existing Remarks**: Validates the correct update of an existing remark, enhancing our confidence in the command's robustness.

## Motivation
Given the central role of the `RemarkCommand` in our application, ensuring its reliability and consistency across various user scenarios is essential. These additional tests are designed to close gaps in the test coverage and prevent potential regressions in future developments.

## Impact
These changes do not affect the existing application functionality outside of the intended enhancements to the test suite. They improve our automated testing capabilities and help maintain high standards of quality assurance.

Feel free to review the changes and provide feedback or approve the pull request if everything looks satisfactory. Thank you for your attention to improving our application's reliability and user experience.
